### PR TITLE
Add net472 and netstandard2.0 as targets

### DIFF
--- a/FluentAssertions.Autofac/FluentAssertions.Autofac.csproj
+++ b/FluentAssertions.Autofac/FluentAssertions.Autofac.csproj
@@ -6,7 +6,7 @@
 
     <PropertyGroup>
         <!-- https://docs.microsoft.com/en-us/dotnet/standard/frameworks#latest-target-framework-versions -->
-        <TargetFrameworks>net48;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net472;net48;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
Adding the following to TargetFrameworks:
* net472
* netstandard2.0

I need support for these targets during a long-running migration project.