### PR TITLE
Add support for ILifetimeScope and other IComponentContexts

### DIFF
--- a/FluentAssertions.Autofac.Tests/AutofacAssertionExtensions_Should.cs
+++ b/FluentAssertions.Autofac.Tests/AutofacAssertionExtensions_Should.cs
@@ -23,6 +23,13 @@ namespace FluentAssertions.Autofac
         }
 
         [Fact]
+        public void Provide_register_extension_on_lifetime_scope()
+        {
+            var scope = new ContainerBuilder().Build().BeginLifetimeScope();
+            scope.Should().Have().Should().BeOfType<ContainerRegistrationAssertions>();
+        }
+
+        [Fact]
         public void Provide_resolve_extension()
         {
             var builder = new ContainerBuilder();

--- a/FluentAssertions.Autofac/AutofacAssertionExtensions.cs
+++ b/FluentAssertions.Autofac/AutofacAssertionExtensions.cs
@@ -12,9 +12,9 @@ namespace FluentAssertions.Autofac
     {
         /// <summary>
         ///     Returns an <see cref="ContainerAssertions" /> object that can be used to assert the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" /> (e.g. <see cref="IContainer"/> or <see cref="ILifetimeScope"/>).
         /// </summary>
-        public static ContainerAssertions Should(this IContainer container)
+        public static ContainerAssertions Should(this IComponentContext container)
         {
             return new ContainerAssertions(container);
         }

--- a/FluentAssertions.Autofac/AutofacExtensions.cs
+++ b/FluentAssertions.Autofac/AutofacExtensions.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Autofac
                     $"Type '{type}' should be auto activated");
         }
 
-        public static void AssertAutoActivates(this IContainer container, Type type)
+        public static void AssertAutoActivates(this IComponentContext container, Type type)
         {
             var registration = container.ComponentRegistry.GetRegistration(type);
             AssertAutoActivates(registration, type);

--- a/FluentAssertions.Autofac/ContainerAssertions.cs
+++ b/FluentAssertions.Autofac/ContainerAssertions.cs
@@ -11,31 +11,31 @@ namespace FluentAssertions.Autofac
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Contains a number of methods to assert that an <see cref="T:Autofac.IContainer" /> is in the expected state.
+    ///     Contains a number of methods to assert that an <see cref="T:Autofac.IComponentContext" /> is in the expected state.
     /// </summary>
 #if !DEBUG
     [System.Diagnostics.DebuggerNonUserCode]
 #endif
-    public class ContainerAssertions : ReferenceTypeAssertions<IContainer, ContainerAssertions>
+    public class ContainerAssertions : ReferenceTypeAssertions<IComponentContext, ContainerAssertions>
     {
         /// <inheritdoc />
         /// <summary>
         ///     Returns the type of the subject the assertion applies on.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        protected override string Identifier => nameof(IContainer);
+        protected override string Identifier => nameof(IComponentContext);
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ContainerAssertions" /> class.
         /// </summary>
         /// <param name="container">The subject</param>
-        public ContainerAssertions(IContainer container) : base(container)
+        public ContainerAssertions(IComponentContext container) : base(container)
         {
         }
 
         /// <summary>
         ///     Returns an <see cref="ContainerRegistrationAssertions" /> object that can be used to assert the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         public ContainerRegistrationAssertions Have()
         {
@@ -61,7 +61,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts the specified type has been registered with auto activation on the current <see cref="IContainer" />.
+        ///     Asserts the specified type has been registered with auto activation on the current <see cref="IComponentContext" />.
         /// </summary>
         public void AutoActivate(Type type)
         {
@@ -69,7 +69,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts the specified type has been registered with auto activation on the current <see cref="IContainer" />.
+        ///     Asserts the specified type has been registered with auto activation on the current <see cref="IComponentContext" />.
         /// </summary>
         public void AutoActivate<TService>()
         {

--- a/FluentAssertions.Autofac/ContainerRegistrationAssertions.cs
+++ b/FluentAssertions.Autofac/ContainerRegistrationAssertions.cs
@@ -7,32 +7,32 @@ namespace FluentAssertions.Autofac
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Contains a number of methods to assert that an <see cref="T:Autofac.IContainer" /> has registered expected
+    ///     Contains a number of methods to assert that an <see cref="T:Autofac.IComponentContext" /> has registered expected
     ///     services.
     /// </summary>
 #if !DEBUG
     [System.Diagnostics.DebuggerNonUserCode]
 #endif
-    public class ContainerRegistrationAssertions : ReferenceTypeAssertions<IContainer, ContainerRegistrationAssertions>
+    public class ContainerRegistrationAssertions : ReferenceTypeAssertions<IComponentContext, ContainerRegistrationAssertions>
     {
         /// <inheritdoc />
         /// <summary>
         ///     Returns the type of the subject the assertion applies on.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        protected override string Identifier => nameof(IContainer);
+        protected override string Identifier => nameof(IComponentContext);
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ContainerRegistrationAssertions" /> class.
         /// </summary>
         /// <param name="subject">The subject</param>
-        public ContainerRegistrationAssertions(IContainer subject) : base(subject)
+        public ContainerRegistrationAssertions(IComponentContext subject) : base(subject)
         {
         }
 
         /// <summary>
         ///     Returns an <see cref="RegisterAssertions" /> object that can be used to assert the current
-        ///     <see cref="IContainer" /> and <see typeparamref="TService" />.
+        ///     <see cref="IComponentContext" /> and <see typeparamref="TService" />.
         /// </summary>
         public RegisterAssertions Registered<TService>()
         {
@@ -41,7 +41,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Returns an <see cref="RegisterAssertions" /> object that can be used to assert the current
-        ///     <see cref="IContainer" /> and the specified type.
+        ///     <see cref="IComponentContext" /> and the specified type.
         /// </summary>
         public RegisterAssertions Registered(Type type)
         {
@@ -50,7 +50,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Returns an <see cref="RegisterAssertions" /> object that can be used to assert the current
-        ///     <see cref="IContainer" /> and the specified instance.
+        ///     <see cref="IComponentContext" /> and the specified instance.
         /// </summary>
         public RegisterAssertions Registered(object instance)
         {
@@ -64,7 +64,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the specified <see typeparamref="TService" /> has not been registered on the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         /// <typeparam name="TService">The service type</typeparam>
         public void NotRegistered<TService>()
@@ -73,7 +73,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the specified service type has not been registered on the current <see cref="IContainer" />.
+        ///     Asserts that the specified service type has not been registered on the current <see cref="IComponentContext" />.
         /// </summary>
         /// <param name="type">The service type</param>
         public void NotRegistered(Type type)
@@ -83,7 +83,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the specified <see typeparamref="TService" /> has not been registered on the current
-        ///     <see cref="IContainer" /> with the specified name.
+        ///     <see cref="IComponentContext" /> with the specified name.
         /// </summary>
         /// <param name="serviceName">The service name</param>
         /// <typeparam name="TService">The service type</typeparam>
@@ -93,7 +93,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the specified service type has not been registered on the current <see cref="IContainer" /> with the
+        ///     Asserts that the specified service type has not been registered on the current <see cref="IComponentContext" /> with the
         ///     specified name.
         /// </summary>
         /// <param name="serviceName">The service name</param>
@@ -105,7 +105,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the specified service type has not been registered on the current <see cref="IContainer" /> with the
+        ///     Asserts that the specified service type has not been registered on the current <see cref="IComponentContext" /> with the
         ///     specified key.
         /// </summary>
         /// <param name="serviceKey">The service key</param>
@@ -116,7 +116,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the specified service type has not been registered on the current <see cref="IContainer" /> with the
+        ///     Asserts that the specified service type has not been registered on the current <see cref="IComponentContext" /> with the
         ///     specified key.
         /// </summary>
         /// <param name="serviceKey">The service key</param>
@@ -129,7 +129,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Returns an <see cref="RegisterGenericSourceAssertions" /> object that can be used to assert the current
-        ///     <see cref="IContainer" /> and the specified generic type.
+        ///     <see cref="IComponentContext" /> and the specified generic type.
         /// </summary>
         public RegisterGenericSourceAssertions RegisteredGeneric(Type genericComponentTypeDefinition)
         {

--- a/FluentAssertions.Autofac/RegisterAssertions.cs
+++ b/FluentAssertions.Autofac/RegisterAssertions.cs
@@ -7,7 +7,7 @@ using Autofac;
 namespace FluentAssertions.Autofac
 {
     /// <summary>
-    ///     Contains a number of methods to assert that an <see cref="IContainer" /> is in the expected state.
+    ///     Contains a number of methods to assert that an <see cref="IComponentContext" /> is in the expected state.
     /// </summary>
 #if !DEBUG
     [System.Diagnostics.DebuggerNonUserCode]
@@ -19,12 +19,12 @@ namespace FluentAssertions.Autofac
         /// </summary>
         /// <param name="subject">The container</param>
         /// <param name="type">The type that should be registered on the container</param>
-        public RegisterAssertions(IContainer subject, Type type) : base(subject, type)
+        public RegisterAssertions(IComponentContext subject, Type type) : base(subject, type)
         {
         }
 
         /// <summary>
-        ///     Asserts that the specified implementation type can be resolved from the current <see cref="IContainer" />.
+        ///     Asserts that the specified implementation type can be resolved from the current <see cref="IComponentContext" />.
         /// </summary>
         /// <typeparam name="TResolve">The type to resolve</typeparam>
         public RegisterAssertions As<TResolve>()
@@ -36,7 +36,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the specified implementation type can be resolved from the current <see cref="IContainer" />.
+        ///     Asserts that the specified implementation type can be resolved from the current <see cref="IComponentContext" />.
         /// </summary>
         /// <param name="type">The type to resolve</param>
         /// <param name="types">Optional types to resolve</param>
@@ -48,7 +48,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the registered service type can be resolved from the current <see cref="IContainer" />.
+        ///     Asserts that the registered service type can be resolved from the current <see cref="IComponentContext" />.
         /// </summary>
         public RegisterAssertions AsSelf()
         {
@@ -57,7 +57,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that all implemented interfaces of the registered service type can be resolved from the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         public RegisterAssertions AsImplementedInterfaces()
         {

--- a/FluentAssertions.Autofac/RegisterGenericSourceAssertions.cs
+++ b/FluentAssertions.Autofac/RegisterGenericSourceAssertions.cs
@@ -11,12 +11,12 @@ namespace FluentAssertions.Autofac
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Contains a number of methods to assert that an <see cref="T:Autofac.IContainer" /> is in the expected state.
+    ///     Contains a number of methods to assert that an <see cref="T:Autofac.IComponentContext" /> is in the expected state.
     /// </summary>
 #if !DEBUG
     [System.Diagnostics.DebuggerNonUserCode]
 #endif
-    public class RegisterGenericSourceAssertions : ReferenceTypeAssertions<IContainer, RegisterGenericSourceAssertions>
+    public class RegisterGenericSourceAssertions : ReferenceTypeAssertions<IComponentContext, RegisterGenericSourceAssertions>
     {
         private readonly Type _genericComponentTypeDefinition;
 
@@ -25,21 +25,21 @@ namespace FluentAssertions.Autofac
         ///     Returns the type of the subject the assertion applies on.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        protected override string Identifier => nameof(IContainer);
+        protected override string Identifier => nameof(IComponentContext);
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="RegisterGenericSourceAssertions" /> class.
         /// </summary>
         /// <param name="subject">The container</param>
         /// <param name="genericComponentTypeDefinition">The type that should be registered on the container</param>
-        public RegisterGenericSourceAssertions(IContainer subject, Type genericComponentTypeDefinition) : base(subject)
+        public RegisterGenericSourceAssertions(IComponentContext subject, Type genericComponentTypeDefinition) : base(subject)
         {
             AssertGenericType(genericComponentTypeDefinition);
             _genericComponentTypeDefinition = genericComponentTypeDefinition;
         }
 
         /// <summary>
-        ///     Asserts that the specified service type can be resolved from the current <see cref="IContainer" />.
+        ///     Asserts that the specified service type can be resolved from the current <see cref="IComponentContext" />.
         /// </summary>
         /// <param name="genericServiceTypeDefinition">The type to resolve</param>
         public RegistrationAssertions As(Type genericServiceTypeDefinition)

--- a/FluentAssertions.Autofac/RegistrationAssertions.cs
+++ b/FluentAssertions.Autofac/RegistrationAssertions.cs
@@ -13,12 +13,12 @@ namespace FluentAssertions.Autofac
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Contains a number of methods to assert that an <see cref="T:Autofac.IContainer" /> registers value services.
+    ///     Contains a number of methods to assert that an <see cref="T:Autofac.IComponentContext" /> registers value services.
     /// </summary>
 #if !DEBUG
     [System.Diagnostics.DebuggerNonUserCode]
 #endif
-    public class RegistrationAssertions : ReferenceTypeAssertions<IContainer, RegistrationAssertions>
+    public class RegistrationAssertions : ReferenceTypeAssertions<IComponentContext, RegistrationAssertions>
     {
         /// <summary>
         ///     The type that should be registered on the container
@@ -33,14 +33,14 @@ namespace FluentAssertions.Autofac
         ///     Returns the type of the subject the assertion applies on.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        protected override string Identifier => nameof(IContainer);
+        protected override string Identifier => nameof(IComponentContext);
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="RegistrationAssertions" /> class.
         /// </summary>
         /// <param name="subject">The container</param>
         /// <param name="type">The type that should be registered on the container</param>
-        public RegistrationAssertions(IContainer subject, Type type) : base(subject)
+        public RegistrationAssertions(IComponentContext subject, Type type) : base(subject)
         {
             Type = type ?? throw new ArgumentNullException(nameof(type));
             _registration = Subject.ComponentRegistry.GetRegistration(Type);
@@ -52,7 +52,7 @@ namespace FluentAssertions.Autofac
         /// </summary>
         /// <param name="subject">The container</param>
         /// <param name="registration"></param>
-        public RegistrationAssertions(IContainer subject, IComponentRegistration registration) : base(subject)
+        public RegistrationAssertions(IComponentContext subject, IComponentRegistration registration) : base(subject)
         {
             _registration = registration ?? throw new ArgumentNullException(nameof(registration));
             Type = registration.Activator.LimitType;
@@ -61,7 +61,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the specified <see typeparamref="TService" /> has been registered on the current
-        ///     <see cref="IContainer" /> with the specified name.
+        ///     <see cref="IComponentContext" /> with the specified name.
         /// </summary>
         /// <param name="name">The service name</param>
         /// <typeparam name="TService">The service type</typeparam>
@@ -71,7 +71,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the specified <see paramref="type" /> has been registered on the current <see cref="IContainer" />
+        ///     Asserts that the specified <see paramref="type" /> has been registered on the current <see cref="IComponentContext" />
         ///     with the specified name.
         /// </summary>
         /// <param name="name">The service name</param>
@@ -85,7 +85,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the specified <see typeparamref="TService" /> has been registered on the current
-        ///     <see cref="IContainer" /> with the specified key.
+        ///     <see cref="IComponentContext" /> with the specified key.
         /// </summary>
         /// <param name="key">The service key</param>
         /// <typeparam name="TService">The service type</typeparam>
@@ -96,7 +96,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the specified <see typeparamref="TService" /> has been registered on the current
-        ///     <see cref="IContainer" /> with the specified key.
+        ///     <see cref="IComponentContext" /> with the specified key.
         /// </summary>
         /// <param name="key">The service key</param>
         /// <param name="type">The service type</param>
@@ -108,7 +108,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the current service type has been registered as singleton on the current <see cref="IContainer" />.
+        ///     Asserts that the current service type has been registered as singleton on the current <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions SingleInstance()
         {
@@ -118,7 +118,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the current service type has been registered as 'instance per dependency' on the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions InstancePerDependency()
         {
@@ -128,7 +128,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the current service type has been registered as 'instance per lifetime scope' on the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions InstancePerLifetimeScope()
         {
@@ -138,7 +138,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the current service type has been registered as 'instance per matching lifetime scope' on the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions InstancePerMatchingLifetimeScope()
         {
@@ -148,7 +148,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the current service type has been registered as 'instance per request' on the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions InstancePerRequest()
         {
@@ -158,7 +158,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the current service type has been registered as 'instance per owned' of the specified
-        ///     <see typeparamref="TService" /> on the current <see cref="IContainer" />.
+        ///     <see typeparamref="TService" /> on the current <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions InstancePerOwned<TService>()
         {
@@ -167,7 +167,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the current service type has been registered as 'instance per owned' of the specified
-        ///     <see paramref="type" /> on the current <see cref="IContainer" />.
+        ///     <see paramref="type" /> on the current <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions InstancePerOwned(Type serviceType)
         {
@@ -177,7 +177,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the current service type has been registered as 'externally owned' on the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions ExternallyOwned()
         {
@@ -186,7 +186,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts that the current service type has been registered as 'owned by lifetime scope' on the current
-        ///     <see cref="IContainer" />.
+        ///     <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions OwnedByLifetimeScope()
         {
@@ -195,7 +195,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts the current service type has been registered using the specified <see typeparamref="TLifetime" /> on the
-        ///     current <see cref="IContainer" />.
+        ///     current <see cref="IComponentContext" />.
         /// </summary>
         /// <param name="assert">An optional custom assertion action to execute on the <typeparamref name="TLifetime" /></param>
         /// <typeparam name="TLifetime"></typeparam>
@@ -210,7 +210,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts the current service type has been registered using the specified <see cref="InstanceSharing" /> on the
-        ///     current <see cref="IContainer" />.
+        ///     current <see cref="IComponentContext" />.
         /// </summary>
         /// <param name="sharing">The instance sharing mode</param>
         public RegistrationAssertions Shared(InstanceSharing sharing)
@@ -221,7 +221,7 @@ namespace FluentAssertions.Autofac
 
         /// <summary>
         ///     Asserts the current service type has been registered using the specified <see cref="InstanceOwnership" /> on the
-        ///     current <see cref="IContainer" />.
+        ///     current <see cref="IComponentContext" />.
         /// </summary>
         /// <param name="ownership">The instance ownership mode</param>
         public RegistrationAssertions Owned(InstanceOwnership ownership)
@@ -231,7 +231,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts the current service type has been registered with auto activation on the current <see cref="IContainer" />.
+        ///     Asserts the current service type has been registered with auto activation on the current <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions AutoActivate()
         {

--- a/FluentAssertions.Autofac/ResolveAssertions.cs
+++ b/FluentAssertions.Autofac/ResolveAssertions.cs
@@ -11,12 +11,12 @@ namespace FluentAssertions.Autofac
     /// <inheritdoc />
     /// <summary>
     ///     Contains a number of methods to assert that expected services can actually be resolved from an
-    ///     <see cref="T:Autofac.IContainer" />.
+    ///     <see cref="T:Autofac.IComponentContext" />.
     /// </summary>
 #if !DEBUG
     [System.Diagnostics.DebuggerNonUserCode]
 #endif
-    public class ResolveAssertions : ReferenceTypeAssertions<IContainer, ResolveAssertions>
+    public class ResolveAssertions : ReferenceTypeAssertions<IComponentContext, ResolveAssertions>
     {
         private readonly Type _serviceType;
         private readonly List<object> _instances = new();
@@ -26,14 +26,14 @@ namespace FluentAssertions.Autofac
         ///     Returns the type of the subject the assertion applies on.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        protected override string Identifier => nameof(IContainer);
+        protected override string Identifier => nameof(IComponentContext);
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ResolveAssertions" /> class.
         /// </summary>
         /// <param name="container">The container</param>
         /// <param name="serviceType">The service type</param>
-        public ResolveAssertions(IContainer container, Type serviceType) : base(container)
+        public ResolveAssertions(IComponentContext container, Type serviceType) : base(container)
         {
             _serviceType = serviceType;
             var typeToResolve = typeof(IEnumerable<>).MakeGenericType(serviceType);
@@ -48,7 +48,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the specified implementation type can be resolved from the current <see cref="IContainer" />.
+        ///     Asserts that the specified implementation type can be resolved from the current <see cref="IComponentContext" />.
         /// </summary>
         /// <typeparam name="TImplementation">The type to resolve</typeparam>
         public RegistrationAssertions As<TImplementation>()
@@ -57,7 +57,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the registered service type can be resolved from the current <see cref="IContainer" />.
+        ///     Asserts that the registered service type can be resolved from the current <see cref="IComponentContext" />.
         /// </summary>
         public RegistrationAssertions AsSelf()
         {
@@ -66,7 +66,7 @@ namespace FluentAssertions.Autofac
 
 
         /// <summary>
-        ///     Asserts that the service type has been registered with auto activation on the current <see cref="IContainer" />.
+        ///     Asserts that the service type has been registered with auto activation on the current <see cref="IComponentContext" />.
         /// </summary>
         public void AutoActivate()
         {
@@ -74,7 +74,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the specified implementation type(s) can be resolved from the current <see cref="IContainer" />.
+        ///     Asserts that the specified implementation type(s) can be resolved from the current <see cref="IComponentContext" />.
         /// </summary>
         /// <param name="type">The type to resolve</param>
         /// <param name="types">Optional types to resolve</param>

--- a/FluentAssertions.Autofac/TypeScanningAssertions.cs
+++ b/FluentAssertions.Autofac/TypeScanningAssertions.cs
@@ -11,12 +11,12 @@ namespace FluentAssertions.Autofac
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Contains a number of methods to assert registered types on an <see cref="T:Autofac.IContainer" />.
+    ///     Contains a number of methods to assert registered types on an <see cref="T:Autofac.IComponentContext" />.
     /// </summary>
 #if !DEBUG
     [System.Diagnostics.DebuggerNonUserCode]
 #endif
-    public class TypeScanningAssertions : ReferenceTypeAssertions<IContainer, TypeScanningAssertions>
+    public class TypeScanningAssertions : ReferenceTypeAssertions<IComponentContext, TypeScanningAssertions>
     {
         /// <summary>
         ///     The types.
@@ -32,7 +32,7 @@ namespace FluentAssertions.Autofac
         ///     Returns the type of the subject the assertion applies on.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        protected override string Identifier => nameof(IContainer);
+        protected override string Identifier => nameof(IComponentContext);
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="TypeScanningAssertions" /> class.
@@ -40,7 +40,7 @@ namespace FluentAssertions.Autofac
         /// <param name="subject"></param>
         /// <param name="types">The types to assert</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public TypeScanningAssertions(IContainer subject, IEnumerable<Type> types) : base(subject)
+        public TypeScanningAssertions(IComponentContext subject, IEnumerable<Type> types) : base(subject)
         {
             Types = FilterTypes(types);
             _registerAssertions = new Lazy<List<RegisterAssertions>>(
@@ -65,7 +65,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the scanned types can be resolved from the current <see cref="IContainer" />
+        ///     Asserts that the scanned types can be resolved from the current <see cref="IComponentContext" />
         ///     as the specified <typeparamref name="T" />.
         /// </summary>
         public TypeScanningAssertions As<T>()
@@ -74,7 +74,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the scanned types can be resolved from the current <see cref="IContainer" />
+        ///     Asserts that the scanned types can be resolved from the current <see cref="IComponentContext" />
         ///     as the specified <paramref name="type" />.
         /// </summary>
         public TypeScanningAssertions As(Type type)
@@ -84,7 +84,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the scanned types can be resolved from the current <see cref="IContainer" /> as self.
+        ///     Asserts that the scanned types can be resolved from the current <see cref="IComponentContext" /> as self.
         /// </summary>
         public TypeScanningAssertions AsSelf()
         {
@@ -93,7 +93,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the scanned types can be resolved from the current <see cref="IContainer" />
+        ///     Asserts that the scanned types can be resolved from the current <see cref="IComponentContext" />
         ///     as their implemented interfaces.
         /// </summary>
         public TypeScanningAssertions AsImplementedInterfaces()
@@ -103,7 +103,7 @@ namespace FluentAssertions.Autofac
         }
 
         /// <summary>
-        ///     Asserts that the scanned types can be resolved from the current <see cref="IContainer" />
+        ///     Asserts that the scanned types can be resolved from the current <see cref="IComponentContext" />
         ///     as the type returned using the specified lambda.
         /// </summary>
         public TypeScanningAssertions As(Func<Type, Type> lambda)


### PR DESCRIPTION
Currently, all assertions accept `IContainer` instances, but they test only `IComponentContext` members (`IContainer` inherits from `IComponentContext`). There are also other `IComponentContext` implementations, e.g. `ILifetimeScope`.

Testing `ILifetimeScope` would be useful in scenarios with more complext Autofac usages (e.g. plugin architecture or multi-tenant containers). I personally would like to test if tenants are configured correctly in my application and each tenant has its `ILifetimeScope`.

Here I suggest simply changing `IContainer` to `IComponentContext` - all tests still pass (I added one with `ILifetimeScope`)